### PR TITLE
Fixing the pattern matching for numeric parameters

### DIFF
--- a/TopicPair.java
+++ b/TopicPair.java
@@ -1,0 +1,161 @@
+package com.github.tocrhz.mqtt.subscriber;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.paho.client.mqttv3.MqttTopic;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * If {@link com.github.tocrhz.mqtt.annotation.NamedValue} is used, use regular matching, if not,
+ * use {@link MqttTopic#isMatched(String, String)} matching
+ *
+ * @author tocrhz
+ */
+public class TopicPair {
+  private static final Pattern TO_PATTERN = Pattern.compile("\\{(\\w+)}");
+  private static final Pattern TO_TOPIC = Pattern.compile("[^/]*\\{\\w+}[^/]*");
+  private static final String STRING_PARAM = "([^/]+)";
+  private static final String NUMBER_PARAM = "(\\\\d+(:?\\\\.\\\\d+)?)";
+
+  private String topic;
+  private Pattern pattern;
+  private TopicParam[] params;
+  private int qos;
+  private boolean shared;
+  private String group;
+
+  public static TopicPair of(
+      String topic, int qos, boolean shared, String group, HashMap<String, Class<?>> paramTypeMap) {
+    Assert.isTrue(topic != null && !topic.isEmpty(), "topic cannot be blank");
+    Assert.isTrue(qos >= 0, "qos min value is 0");
+    Assert.isTrue(qos <= 2, "qos max value is 2");
+    TopicPair topicPair = new TopicPair();
+    if (topic.contains("{")) {
+      LinkedList<TopicParam> params = new LinkedList<>();
+      topicPair.pattern = toPattern(topic, params, paramTypeMap);
+      topicPair.params = params.toArray(new TopicParam[0]);
+      topicPair.topic = TO_TOPIC.matcher(topic).replaceAll("+");
+    } else {
+      topicPair.topic = topic;
+    }
+    MqttTopic.validate(topicPair.topic, true);
+    topicPair.qos = qos;
+    topicPair.shared = shared;
+    topicPair.group = group;
+    return topicPair;
+  }
+
+  private static Pattern toPattern(
+      String topic, LinkedList<TopicParam> params, HashMap<String, Class<?>> paramTypeMap) {
+    String pattern = replaceSymbols(topic);
+    Matcher matcher = TO_PATTERN.matcher(pattern);
+    StringBuffer buffer = new StringBuffer("^");
+    int group = 1;
+    while (matcher.find()) {
+      String paramName = matcher.group(1);
+      params.add(new TopicParam(paramName, group));
+      if (paramTypeMap.containsKey(paramName)) {
+        Class<?> paramType = paramTypeMap.get(paramName);
+        if (Number.class.isAssignableFrom(paramType)) {
+          matcher.appendReplacement(buffer, NUMBER_PARAM);
+          group += 2;
+        } else {
+          matcher.appendReplacement(buffer, STRING_PARAM);
+          ++group;
+        }
+      } else {
+        matcher.appendReplacement(buffer, STRING_PARAM);
+      }
+    }
+    matcher.appendTail(buffer);
+    buffer.append("$");
+    return Pattern.compile(buffer.toString());
+  }
+
+  public String getTopic(boolean sharedEnable) {
+    if (this.shared && sharedEnable) {
+      if (StringUtils.hasText(this.group)) {
+        return "$share/" + this.group + "/" + this.topic;
+      } else {
+        return "$queue/" + this.topic;
+      }
+    }
+    return this.topic;
+  }
+
+  public int getQos() {
+    return qos;
+  }
+
+  public boolean isMatched(String topic) {
+    if (this.pattern != null) {
+      return pattern.matcher(topic).matches();
+    } else {
+      return MqttTopic.isMatched(this.topic, topic);
+    }
+  }
+
+  public HashMap<String, String> getPathValueMap(String topic) {
+    HashMap<String, String> map = new HashMap<>();
+    if (pattern != null) {
+      Matcher matcher = pattern.matcher(topic);
+      if (matcher.find()) {
+        for (int i = 0; i < params.length; i++) {
+          String group = matcher.group(params[i].getAt());
+          map.put(params[i].getName(), group);
+        }
+      }
+    }
+    return map;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TopicPair topicPair = (TopicPair) o;
+    return Objects.equals(topic, topicPair.topic);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(topic);
+  }
+
+  public int order() {
+    return this.pattern == null ? 1 : -params.length;
+  }
+
+  private static String replaceSymbols(String topic) {
+    StringBuilder sb = new StringBuilder();
+    char[] chars = topic.toCharArray();
+    for (char ch : chars) {
+      switch (ch) {
+        case '$':
+        case '^':
+        case '.':
+        case '?':
+        case '*':
+        case '|':
+        case '(':
+        case ')':
+        case '[':
+        case ']':
+        case '\\':
+          sb.append('\\').append(ch);
+          break;
+        case '+':
+          sb.append("[^/]+");
+          break;
+        default:
+          sb.append(ch);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <paho.mqttv3.version>1.2.5</paho.mqttv3.version>
         <jackson.version>2.11.2</jackson.version>
         <lombok.version>1.18.12</lombok.version>
+        <jupiter.version>5.7.1</jupiter.version>
     </properties>
 
     <dependencies>
@@ -90,6 +91,13 @@
             <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
+        
+        <dependency>
+    		<groupId>org.junit.jupiter</groupId>
+    		<artifactId>junit-jupiter-engine</artifactId>
+    		<version>${jupiter.version}</version>
+		</dependency>
+        
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/tocrhz/mqtt/subscriber/TopicParam.java
+++ b/src/main/java/com/github/tocrhz/mqtt/subscriber/TopicParam.java
@@ -1,0 +1,30 @@
+/** */
+package com.github.tocrhz.mqtt.subscriber;
+
+/** @author tjheiska */
+public class TopicParam {
+  private String name;
+  private int at;
+
+  public TopicParam(String name, int at) {
+    super();
+    this.name = name;
+    this.at = at;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getAt() {
+    return at;
+  }
+
+  public void setAt(int at) {
+    this.at = at;
+  }
+}

--- a/src/test/java/PatternTests.java
+++ b/src/test/java/PatternTests.java
@@ -1,0 +1,30 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.tocrhz.mqtt.subscriber.TopicPair;
+
+/** */
+
+/** @author tjheiska */
+public class PatternTests {
+
+  @Test
+  public void testTopicPair()
+      throws IllegalArgumentException, IllegalAccessException, NoSuchFieldException,
+          SecurityException {
+    HashMap<String, Class<?>> paramTypeMap = new HashMap<>();
+    paramTypeMap.put("projectId", Long.class);
+    paramTypeMap.put("userName", String.class);
+
+    TopicPair topicPair = TopicPair.of("{projectId}/{userName}", 0, false, null, paramTypeMap);
+    String topic = "0/user1";
+
+    assert (topicPair.isMatched(topic));
+    HashMap<String, String> map = topicPair.getPathValueMap(topic);
+    assertEquals("0", map.get("projectId"));
+    assertEquals("user1", map.get("userName"));
+  }
+}


### PR DESCRIPTION
There is an issue with numeric parameter declaring two groups in pattern (the whole number and optional decimals). This commit implements JUnit test that reveals the bug and also a fix for it.