### PR TITLE
Add multilevel wildcard support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         
         <dependency>
     		<groupId>org.junit.jupiter</groupId>
-    		<artifactId>junit-jupiter-engine</artifactId>
+    		<artifactId>junit-jupiter</artifactId>
     		<version>${jupiter.version}</version>
             <optional>true</optional>
             <scope>test</scope>
@@ -109,6 +109,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
             </plugin>
+            <plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+			</plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/github/tocrhz/mqtt/subscriber/TopicPair.java
+++ b/src/main/java/com/github/tocrhz/mqtt/subscriber/TopicPair.java
@@ -154,6 +154,6 @@ public class TopicPair {
                     sb.append(ch);
             }
         }
-        return sb.toString();
+        return sb.toString().replaceAll("/#$", "/.*");
     }
 }

--- a/src/test/java/PatternTests.java
+++ b/src/test/java/PatternTests.java
@@ -1,6 +1,8 @@
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import com.github.tocrhz.mqtt.subscriber.TopicPair;
 
@@ -26,4 +28,28 @@ public class PatternTests {
         assertEquals("0", map.get("projectId"));
         assertEquals("user1", map.get("userName"));
     }
+
+    @Test
+    public void testHashTagPattern()
+      throws NoSuchFieldException, SecurityException, IllegalArgumentException,
+          IllegalAccessException {
+        final String topicFilter = "my/hierarchical/topics/{param}/#";
+        HashMap<String, Class<?>> paramTypeMap = new HashMap<>();
+        paramTypeMap.put("param", String.class);
+        TopicPair topicPair = TopicPair.of(topicFilter, 0, false, null, paramTypeMap);
+        final Field patternField = TopicPair.class.getDeclaredField("pattern");
+        patternField.setAccessible(true);
+        final Pattern pattern = (Pattern) patternField.get(topicPair);
+        final String testTopic = "my/hierarchical/topics/one/with/subtopics";
+        assertEquals("^my/hierarchical/topics/([^/]+)/.*$", pattern.pattern());
+        assert (pattern.matcher(testTopic).matches());
+        assert (topicPair.isMatched(testTopic));
+    }
+
+    @Test
+    public void testMatchAll() {
+        TopicPair topicPair = TopicPair.of("#", 0, false, null, new HashMap<>());
+        assert (topicPair.isMatched("this/should/be/matched"));
+    }
+
 }


### PR DESCRIPTION
Hi. If you don't mind I would also like to suggest this patch to add feature allowing developer to subscribe topics ending with multilevel wildcard (#). Also fixed the pom.xml so that maven will actually run the tests I added support last time.
