### PR TITLE
解决Connector启动顺序导致在Connector之后扫描出来的MqttSubscriber无法监听的问题。

### DIFF
--- a/src/main/java/com/github/tocrhz/mqtt/autoconfigure/MqttAutoConfiguration.java
+++ b/src/main/java/com/github/tocrhz/mqtt/autoconfigure/MqttAutoConfiguration.java
@@ -49,8 +49,8 @@ public class MqttAutoConfiguration {
     @Bean
     @Order(1013)
     @ConditionalOnMissingBean(MqttPublisher.class)
-    public MqttPublisher mqttPublisher() {
-        return new MqttPublisher();
+    public MqttPublisher mqttPublisher(MqttConnector connector) {
+        return new MqttPublisher(connector);
     }
 
     /**

--- a/src/main/java/com/github/tocrhz/mqtt/autoconfigure/MqttSubscribeProcessor.java
+++ b/src/main/java/com/github/tocrhz/mqtt/autoconfigure/MqttSubscribeProcessor.java
@@ -3,6 +3,7 @@ package com.github.tocrhz.mqtt.autoconfigure;
 import com.github.tocrhz.mqtt.annotation.MqttSubscribe;
 import com.github.tocrhz.mqtt.subscriber.MqttSubscriber;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.stereotype.Component;
@@ -20,11 +21,11 @@ import java.util.LinkedList;
 @Component
 public class MqttSubscribeProcessor implements BeanPostProcessor {
 
-    // subscriber cache
-    static final LinkedList<MqttSubscriber> SUBSCRIBERS = new LinkedList<>();
-
     @Value("${mqtt.disable:false}")
     private Boolean disable;
+
+    @Autowired
+    MqttConnector mqttConnector;
 
     @Override
     public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
@@ -32,7 +33,7 @@ public class MqttSubscribeProcessor implements BeanPostProcessor {
             Method[] methods = bean.getClass().getMethods();
             for (Method method : methods) {
                 if (method.isAnnotationPresent(MqttSubscribe.class)) {
-                    SUBSCRIBERS.add(MqttSubscriber.of(bean, method));
+                    mqttConnector.subscribe(MqttSubscriber.of(bean, method));
                 }
             }
         }

--- a/src/main/java/com/github/tocrhz/mqtt/publisher/MqttPublisher.java
+++ b/src/main/java/com/github/tocrhz/mqtt/publisher/MqttPublisher.java
@@ -18,6 +18,12 @@ import java.util.Objects;
  */
 public class MqttPublisher {
     private final static Logger log = LoggerFactory.getLogger(MqttPublisher.class);
+    private MqttConnector connector;
+
+    public MqttPublisher(MqttConnector connector) {
+
+        this.connector = connector;
+    }
 
     /**
      * 发送消息到指定主题 qos=1
@@ -54,7 +60,7 @@ public class MqttPublisher {
      * @throws NullPointerException     if client not exists
      */
     public void send(String clientId, String topic, Object payload) {
-        send(clientId, topic, payload, MqttConnector.getDefaultQosById(clientId), false, null);
+        send(clientId, topic, payload, connector.getDefaultQosById(clientId), false, null);
     }
 
     /**
@@ -68,7 +74,7 @@ public class MqttPublisher {
      * @throws NullPointerException     if client not exists
      */
     public void send(String clientId, String topic, Object payload, IMqttActionListener callback) {
-        send(clientId, topic, payload, MqttConnector.getDefaultQosById(clientId), false, callback);
+        send(clientId, topic, payload, connector.getDefaultQosById(clientId), false, callback);
     }
 
 
@@ -131,7 +137,7 @@ public class MqttPublisher {
      */
     public void send(String clientId, String topic, Object payload, int qos, boolean retained, IMqttActionListener callback) {
         Assert.isTrue(topic != null && !topic.trim().isEmpty(), "topic cannot be blank.");
-        IMqttAsyncClient client = Objects.requireNonNull(MqttConnector.getClientById(clientId));
+        IMqttAsyncClient client = Objects.requireNonNull(connector.getClientById(clientId));
         byte[] bytes = MqttConversionService.getSharedInstance().toBytes(payload);
         if (bytes == null) {
             return;

--- a/src/main/java/com/github/tocrhz/mqtt/subscriber/MqttSubscriber.java
+++ b/src/main/java/com/github/tocrhz/mqtt/subscriber/MqttSubscriber.java
@@ -39,7 +39,6 @@ public class MqttSubscriber {
     private Object bean;
     private Method method;
     private LinkedList<ParameterModel> parameters;
-    private int order;
 
     private final LinkedList<TopicPair> topics = new LinkedList<>();
 
@@ -52,10 +51,6 @@ public class MqttSubscriber {
         subscriber.parameters.stream()
                 .filter(model -> model.getName() != null)
                 .forEach(model -> paramTypeMap.put(model.getName(), model.getType()));
-        if (method.isAnnotationPresent(Order.class)) {
-            Order order = method.getAnnotation(Order.class);
-            subscriber.order = order.value();
-        }
         MqttSubscribe subscribe = method.getAnnotation(MqttSubscribe.class);
         subscriber.clientIds = subscribe.clients();
         subscriber.setTopics(subscribe, paramTypeMap);
@@ -174,9 +169,6 @@ public class MqttSubscriber {
         }
     }
 
-    public int getOrder() {
-        return order;
-    }
 
     public LinkedList<TopicPair> getTopics() {
         return topics;
@@ -192,6 +184,38 @@ public class MqttSubscriber {
             }
         }
         return false;
+    }
+
+    public String[] getClientIds() {
+        return clientIds;
+    }
+
+    public void setClientIds(String[] clientIds) {
+        this.clientIds = clientIds;
+    }
+
+    public Object getBean() {
+        return bean;
+    }
+
+    public void setBean(Object bean) {
+        this.bean = bean;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public void setMethod(Method method) {
+        this.method = method;
+    }
+
+    public LinkedList<ParameterModel> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(LinkedList<ParameterModel> parameters) {
+        this.parameters = parameters;
     }
 
     @Override


### PR DESCRIPTION
MqttConnector的启动顺序和[MqttSubscribeProcessor的扫描顺序不一致导致部分或全部topic无法监听的情况。